### PR TITLE
Expose `sparse` option for indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,8 +528,10 @@ custom checking.
 For the `unique` option to work, `index` must be `true`, `1`, or `-1`. The error message for uniqueness is very generic. It's best to define your own using
 `MyCollection.simpleSchema().messages()`. The error type string is "notUnique".
 
+You can use the `sparse` option along with the `index` and `unique` options to tell MongoDB to build a [sparse index](http://docs.mongodb.org/manual/core/index-sparse/#index-type-sparse). By default, MongoDB will only permit one document that lacks the indexed field. By setting the `sparse` option to `true`, the index will only contain entries for documents that have the indexed field. The index skips over any document that is missing the field. This is helpful when indexing on a key in an array of sub-documents. Learn more in the [MongoDB docs](http://docs.mongodb.org/manual/core/index-unique/#unique-index-and-missing-field).
+
 Indexes are built in the background so indexing does *not* block other database
-queries.
+queries. 
 
 ### custom
 

--- a/collection2.js
+++ b/collection2.js
@@ -4,6 +4,7 @@
 SimpleSchema.extendOptions({
   index: Match.Optional(Match.OneOf(Number, String, Boolean)),
   unique: Match.Optional(Boolean),
+  sparse: Match.Optional(Boolean),
   denyInsert: Match.Optional(Boolean),
   denyUpdate: Match.Optional(Boolean)
 });
@@ -97,7 +98,7 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
         var idxFieldName = fieldName.replace(/\.\$\./g, ".");
         index[idxFieldName] = indexValue;
         var unique = !!definition.unique && (indexValue === 1 || indexValue === -1);
-        var sparse = !!definition.optional && unique;
+        var sparse = definition.sparse && unique;
 
         if (indexValue === false) {
           dropIndex(self, indexName);
@@ -271,7 +272,7 @@ function doValidate(type, args, skipAutoValue, userId, isFromTrustedCode) {
   if ((Meteor.isServer || isLocalCollection) && options.getAutoValues === false) {
     skipAutoValue = true;
   }
-  
+
   // Preliminary cleaning on both client and server. On the server and for local
   // collections, automatic values will also be set at this point.
   doClean(doc, ((Meteor.isServer || isLocalCollection) && !skipAutoValue), options.filter !== false, options.autoConvert !== false, options.removeEmptyStrings !== false, options.trimStrings !== false);


### PR DESCRIPTION
As the package works now, the following use case fails:

```js
var Things = new Mongo.Collection('things');

var SmallerThingSchema = new SimpleSchema({
  foo: {
    type: String,
    index: true,
    unique: true
  },
});

var ThingSchema = new SimpleSchema({
  name: {
    type: String,
    index: true,
    unique: true
  },
  smallerThings: {
    type: [SmallerThingSchema]
  }
});

Things.attachSchema(ThingSchema);

var thingOne = {
  name: "Thing One",
  smallerThings: []
};

Things.insert(thingOne);

var thingTwo = {
  name: "Thing Two",
  smallerThings: []
};

Things.insert(thingTwo);
// -> MongoError: E11000 duplicate key error index: meteor.things.$c2_smallerThings.$.chipId  dup key: { : null }
```

As Mongo specifies in ["Unique Index and Missing Field"](http://docs.mongodb.org/manual/core/index-unique/#unique-index-and-missing-field) section of their docs, _If a document does not have a value for the indexed field in a unique index, the index will store a null value for this document. Because of the unique constraint, MongoDB will only permit one document that lacks the indexed field. If there is more than one document without a value for the indexed field or is missing the indexed field, the index build will fail with a duplicate key error._

The solution to that is building a sparse index. This code exposes `sparse` as a schema option, rather than relying on the `optional` field like before.

So now this makes the above use case work
```js
var SmallerThingSchema = new SimpleSchema({
  foo: {
    type: String,
    index: true,
    unique: true,
    sparse: true
  },
});
```