### PR TITLE
Upsert (update) validation failing if document is being selected by id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .build*
 .npm*
 .meteor*
+.idea
 smart.lock
 /nbproject/
 /packages/

--- a/collection2.js
+++ b/collection2.js
@@ -344,7 +344,7 @@ function doValidate(type, args, getAutoValues, userId, isFromTrustedCode) {
   // probably isn't any better way right now.
   if (Meteor.isServer && isUpsert && _.isObject(selector)) {
     var set = docToValidate.$set || {};
-    docToValidate.$set = _.clone(selector);
+    docToValidate.$set = _.omit(_.clone(selector), '_id');
     _.extend(docToValidate.$set, set);
   }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -613,6 +613,31 @@ if (Meteor.isServer) {
     });
   });
 
+  Tinytest.addAsync('Collection2 - Upsert as update should update entity by _id - Valid', function (test, next) {
+    books.remove({});
+
+    var id = books.insert({title: 'new', author: 'author new', copies: 2});
+
+    books.upsert({
+      _id: id
+    }, {
+      $set: {
+        title: "Ulysses",
+        author: "James Joyce",
+        copies: 1
+      }
+    }, function (error, result) {
+
+      test.isFalse(!!error, 'We expected the upsert not to trigger an error since the doc is valid for an insert');
+      test.equal(result.numberAffected, 1, 'Upsert should update one record');
+
+      var invalidKeys = books.simpleSchema().namedContext().invalidKeys();
+      test.equal(invalidKeys.length, 0, 'We should get no invalidKeys back');
+
+      next();
+    });
+  });
+
   Tinytest.addAsync('Collection2 - Upsert as Update - Valid', function (test, next) {
     books.remove({});
 


### PR DESCRIPTION
Yesterday we encountered with an issue, which was preventing us to perform an `upsert` using such selector `{_id: id}`. The problem is that `collection2` is merging selector and modifier.

I wrote a test which is simulating the issue and also I attempted to perform a fix, by excluding `_id` from modifier. Tests are passing, but it would be nice if someone could check if this is not going to lead to some additional bugs.

Long story short:
This works: 
```
books.upsert({_id: id}, {$set: {title: "Ulysses", author: "James Joyce", copies: 1}}, {validate: false});
```
This didn't work: 
```
books.upsert({_id: id}, {$set: {title: "Ulysses", author: "James Joyce", copies: 1}});
```