### PR TITLE
Allow for $addToSet to specify the value for a required array field

### DIFF
--- a/collection2.js
+++ b/collection2.js
@@ -346,6 +346,15 @@ function doValidate(type, args, getAutoValues, userId, isFromTrustedCode) {
     var set = docToValidate.$set || {};
     docToValidate.$set = _.clone(selector);
     _.extend(docToValidate.$set, set);
+
+    var addToSet = docToValidate.$addToSet;
+    if (addToSet) {
+      var addToSetArrays = {};
+      for (var index in addToSet) {
+        addToSetArrays[index] = [addToSet[index]];
+      }
+      _.extend(docToValidate.$set, addToSetArrays);
+    }
   }
 
   // Set automatic values for validation on the client.

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -763,6 +763,38 @@ if (Meteor.isServer) {
       next();
     });
   });
+
+  Tinytest.addAsync('Collection2 - Upsert - addToSet', function (test, next) {
+    var addToSetUpsert = new Mongo.Collection("addToSetUpsert");
+    addToSetUpsert.attachSchema(new SimpleSchema({
+      foo: {
+        type: String
+      },
+      values: {
+        type: [String]
+      }
+    }));
+
+    addToSetUpsert.remove({});
+
+    addToSetUpsert.upsert({
+      foo: 'bar'
+    }, {
+      $addToSet: {
+        values: 'asdf'
+      }
+    }, function (error, result) {
+      // can't do test.equal(error, null) because test.equal throws an error
+      test.equal(error === null, true, "Using $addToSet to specify required value failed");
+      var _id = result.insertedId;
+      test.equal(addToSetUpsert.findOne(_id), {
+        _id: _id,
+        foo: 'bar',
+        values: ['asdf']
+      });
+      next();
+    });
+  });
 }
 
 // Ensure that there are no errors when using a schemaless collection


### PR DESCRIPTION
The handling of inserts required by upserts is "prone to errors", but this at least solves the problem in a single case. 