### PR TITLE
Added "registered_emails" field to User Schema 

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Schema.User = new SimpleSchema({
     "emails.$.verified": {
         type: Boolean
     },
+    // Use this registered_emails field if you are using splendido:meteor-accounts-emails-field / splendido:meteor-accounts-meld
+    registered_emails: { 
+        type: [Object], 
+        optional: true,
+        blackbox: true 
+    },
     createdAt: {
         type: Date
     },


### PR DESCRIPTION
I've added the "registered_emails" field to the User Schema in the Readme, for compatibility with https://github.com/splendido/meteor-accounts-meld and https://github.com/splendido/meteor-accounts-emails-field.

This comes from here: https://github.com/splendido/meteor-accounts-emails-field/issues/39
And here: https://github.com/splendido/meteor-accounts-meld/issues/26

Sorry if I am missing something in the process... first pull-request in Github in my life :stuck_out_tongue: