### PR TITLE
Updating example for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Obviously, when you attach a schema, you must know what the schema should be. Fo
 here is an example schema, which you might have to adjust for your own needs:
 
 ```js
-Schema = {};
+var Schemas = {};
 
-Schema.UserCountry = new SimpleSchema({
+Schemas.UserCountry = new SimpleSchema({
     name: {
         type: String
     },
@@ -156,7 +156,7 @@ Schema.UserCountry = new SimpleSchema({
     }
 });
 
-Schema.UserProfile = new SimpleSchema({
+Schemas.UserProfile = new SimpleSchema({
     firstName: {
         type: String,
         optional: true
@@ -188,12 +188,12 @@ Schema.UserProfile = new SimpleSchema({
         optional: true
     },
     country: {
-        type: Schema.UserCountry,
+        type: Schemas.UserCountry,
         optional: true
     }
 });
 
-Schema.User = new SimpleSchema({
+Schemas.User = new SimpleSchema({
     username: {
         type: String,
         // For accounts-password, either emails or username is required, but not both. It is OK to make this
@@ -228,7 +228,7 @@ Schema.User = new SimpleSchema({
         type: Date
     },
     profile: {
-        type: Schema.UserProfile,
+        type: Schemas.UserProfile,
         optional: true
     },
     // Make sure this services field is in your schema if you're using any of the accounts packages
@@ -264,7 +264,7 @@ Schema.User = new SimpleSchema({
     }
 });
 
-Meteor.users.attachSchema(Schema.User);
+Meteor.users.attachSchema(Schemas.User);
 ```
 
 This schema has not been thoroughly vetted to ensure


### PR DESCRIPTION
This is just to keep the User profile example code consistent with the first example schema. In the first one we use "Schemas" and then the second one it is "Schema". This can cause confusion when trying to integrate the two.

Feel free to discuss.
