### PR TITLE
Update raix:eventemitter

### DIFF
--- a/package/collection2/.versions
+++ b/package/collection2/.versions
@@ -35,7 +35,7 @@ mongo-id@1.0.7
 npm-mongo@3.1.1
 ordered-dict@1.1.0
 promise@0.11.1
-raix:eventemitter@0.1.3
+raix:eventemitter@1.0.0
 random@1.1.0
 reload@1.2.0
 retry@1.1.0

--- a/package/collection2/package.js
+++ b/package/collection2/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: "aldeed:collection2",
   summary: "Automatic validation of Meteor Mongo insert and update operations on the client and server",
-  version: "3.0.1",
+  version: "3.0.2",
   documentation: "../../README.md",
   git: "https://github.com/aldeed/meteor-collection2.git"
 });
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
   api.use('mongo@1.0.4');
   api.imply('mongo');
   api.use('minimongo@1.0.0');
-  api.use('raix:eventemitter@0.1.3');
+  api.use('raix:eventemitter@1.0.0');
   api.use('ecmascript@0.6.1');
   api.use('tmeasday:check-npm-versions@0.3.1');
 


### PR DESCRIPTION
`raix:eventemitter` removed `underscore` from their package.