### PR TITLE
Fix bug where upserts with query operators fail

### DIFF
--- a/package/collection2/lib.js
+++ b/package/collection2/lib.js
@@ -1,0 +1,14 @@
+export function fromEntries(entries) {
+  return entries.reduce((obj, [key, value]) => ((obj[key] = value), obj), {});
+}
+
+export function removeQueryOperators(selector) {
+  return fromEntries(
+    Object.entries(selector).filter(([key, value]) => {
+      return !(
+        key.startsWith("$") ||
+        Object.keys(value).some(subKey => subKey.startsWith("$"))
+      );
+    })
+  );
+}

--- a/tests/.meteor/versions
+++ b/tests/.meteor/versions
@@ -1,4 +1,4 @@
-aldeed:collection2@3.0.1
+aldeed:collection2@3.0.2
 allow-deny@1.1.0
 autopublish@1.0.7
 autoupdate@1.5.0


### PR DESCRIPTION
Upserts with operators were having the operators copied into the object for validation causing validation to fail. This commit naively removes omits all keys from the selector if they start with  or contain an object with keys starting with "$". The new code only searches one level deep.

This should fix the issue found on the forums here: https://forums.meteor.com/t/simpl-schema-update-error-while-using-lte-operator-when-calling-update-by-the-field-of-type-date/50414